### PR TITLE
feat: split the prepare command from the wait command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,23 @@ Wait for 5 seconds without any `POST` calls to `/graphql` endpoint
 cy.waitForNetworkIdle('POST', '/graphql', 5000)
 ```
 
+## Separate prepare
+
+Sometimes the network calls start early. For example, if the network calls are kicked off by the `cy.visit` you want to start capturing the timestamps before it, but wait for the network to be idle after. You can start listening using the `prepare` call like this.
+
+```js
+cy.waitForNetworkIdlePrepare({
+  method: 'GET',
+  pattern: '*',
+  alias: 'calls',
+})
+cy.visit('/')
+// now wait for the "@calls" to finish
+cy.waitForNetworkIdle('@calls', 1000)
+```
+
+Notice the use of the alias parameter to correctly listen to the intercepted calls.
+
 ## Yields
 
 The command yields an object with a few timestamps and the number of network calls. See the [src/index.d.ts](./src/index.d.ts) for precise fields

--- a/cypress/integration/button.js
+++ b/cypress/integration/button.js
@@ -4,10 +4,15 @@ import('../../src')
 
 it('starts listening before', () => {
   cy.visit('/button')
+  cy.waitForNetworkIdlePrepare({
+    method: 'GET',
+    pattern: '/user',
+    alias: 'user',
+  })
   cy.get('#fetch').click()
-  cy.waitForNetworkIdle('/user', 1000)
-    .should('have.keys', 'started', 'finished', 'waited', 'callCount')
-    .then(({ waited, callCount }) => {
-      expect(callCount, 'callCount').to.equal(1)
-    })
+  // cy.waitForNetworkIdle('/user', 1000)
+  //   .should('have.keys', 'started', 'finished', 'waited', 'callCount')
+  //   .then(({ waited, callCount }) => {
+  //     expect(callCount, 'callCount').to.equal(1)
+  //   })
 })

--- a/cypress/integration/button.js
+++ b/cypress/integration/button.js
@@ -10,9 +10,12 @@ it('starts listening before', () => {
     alias: 'user',
   })
   cy.get('#fetch').click()
-  // cy.waitForNetworkIdle('/user', 1000)
-  //   .should('have.keys', 'started', 'finished', 'waited', 'callCount')
-  //   .then(({ waited, callCount }) => {
-  //     expect(callCount, 'callCount').to.equal(1)
-  //   })
+  cy.waitForNetworkIdle('@user', 1000)
+    .should('have.keys', 'started', 'finished', 'waited', 'callCount')
+    .then(({ waited, callCount }) => {
+      expect(callCount, 'callCount').to.equal(1)
+      // the expected time is a little tricky, since it might have
+      // finished _before_ the cy.waitForNetworkIdle was called
+      expect(waited, 'waited').to.be.within(900, 1100)
+    })
 })

--- a/cypress/integration/button.js
+++ b/cypress/integration/button.js
@@ -16,6 +16,7 @@ it('starts listening before', () => {
       expect(callCount, 'callCount').to.equal(1)
       // the expected time is a little tricky, since it might have
       // finished _before_ the cy.waitForNetworkIdle was called
-      expect(waited, 'waited').to.be.within(900, 1100)
+      // so let's give it a range around the 1 second mark
+      expect(waited, 'waited').to.be.within(800, 1200)
     })
 })

--- a/cypress/integration/button.js
+++ b/cypress/integration/button.js
@@ -1,0 +1,13 @@
+/// <reference path="../../src/index.d.ts" />
+
+import('../../src')
+
+it('starts listening before', () => {
+  cy.visit('/button')
+  cy.get('#fetch').click()
+  cy.waitForNetworkIdle('/user', 1000)
+    .should('have.keys', 'started', 'finished', 'waited', 'callCount')
+    .then(({ waited, callCount }) => {
+      expect(callCount, 'callCount').to.equal(1)
+    })
+})

--- a/cypress/integration/delayed.js
+++ b/cypress/integration/delayed.js
@@ -1,0 +1,19 @@
+/// <reference path="../../src/index.d.ts" />
+
+import('../../src')
+
+it('uses the response timestamp', () => {
+  cy.visit('/delayed')
+
+  cy.waitForNetworkIdle('GET', '/user/delayed', 3000)
+    .should('have.keys', 'started', 'finished', 'waited', 'callCount')
+    .then(({ waited, callCount }) => {
+      // the page makes an Ajax call after 1500 ms
+      // which is delayed by 1000 ms on the server
+      // thus total resolve time should be:
+      // 1000 + 1000 + 3000
+      // but probably under 7 seconds
+      expect(waited, 'waited ms').to.be.within(5000, 7000)
+      expect(callCount, 'callCount').to.equal(1)
+    })
+})

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -1,6 +1,6 @@
 /// <reference path="../../src/index.d.ts" />
 
-import('../..')
+import '../..'
 
 it('waits for the network call', () => {
   cy.visit('/')

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -15,19 +15,3 @@ it('waits for the network call', () => {
       expect(callCount, 'callCount').to.equal(1)
     })
 })
-
-it('uses the response timestamp', () => {
-  cy.visit('/delayed')
-
-  cy.waitForNetworkIdle('GET', '/user/delayed', 3000)
-    .should('have.keys', 'started', 'finished', 'waited', 'callCount')
-    .then(({ waited, callCount }) => {
-      // the page makes an Ajax call after 1500 ms
-      // which is delayed by 1000 ms on the server
-      // thus total resolve time should be:
-      // 1000 + 1000 + 3000
-      // but probably under 7 seconds
-      expect(waited, 'waited ms').to.be.within(5000, 7000)
-      expect(callCount, 'callCount').to.equal(1)
-    })
-})

--- a/server/button.html
+++ b/server/button.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <title>Example</title>
+  </head>
+  <body>
+    <h1>cypress-network-idle button</h1>
+    <button id="fetch">Fetch</button>
+    <script>
+      document.getElementById('fetch').addEventListener('click', () => {
+        fetch('/user').then((r) => r.json())
+      })
+    </script>
+  </body>
+</html>

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,12 @@ const htmlDelayed = (req, res) => {
   micro.send(res, 200, text)
 }
 
+const htmlButton = (req, res) => {
+  const filename = path.join(__dirname, 'button.html')
+  const text = fs.readFileSync(filename, 'utf8')
+  micro.send(res, 200, text)
+}
+
 const user = (req, res) => {
   micro.send(res, 200, {
     name: 'John Doe',
@@ -35,6 +41,7 @@ const userDelayed = (req, res) => {
 module.exports = dispatch()
   .dispatch('/', 'GET', html)
   .dispatch('/delayed', 'GET', htmlDelayed)
+  .dispatch('/button', 'GET', htmlButton)
   .dispatch('/user', 'GET', user)
   .dispatch('/user/delayed', 'GET', userDelayed)
   .otherwise(html)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@
 /// <reference types="cypress" />
 
 declare namespace Cypress {
-  interface Chainable {
+  interface Chainable<Subject> {
     /**
      * Wait for the network to be idle for N milliseconds.
      * @param waitMs Milliseconds after the last network call
@@ -26,10 +26,20 @@ declare namespace Cypress {
      * @param waitMs Milliseconds after the last network call
      */
     waitForNetworkIdle(
-      method: HttpMethod,
+      method: string,
       pattern: string,
       waitMs: number,
     ): Chainable<WaitForNetworkIdleResult>
+
+    waitForNetworkIdlePrepare(
+      options: WaitForNetworkIdleOptions,
+    ): Chainable<WaitForNetworkIdleResult>
+  }
+
+  interface WaitForNetworkIdleOptions {
+    method?: string
+    pattern: string
+    alias: string
   }
 
   interface WaitForNetworkIdleResult {

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,14 @@ function parseArgs(a1, a2, a3) {
 
 function waitForNetworkIdle(a1, a2, a3) {
   if (typeof a1 === 'string' && a1.startsWith('@') && typeof a2 === 'number') {
+    const alias = a1.substr(1)
+
+    const counters = Cypress.env(`networkIdleCounters_${alias}`)
+    if (!counters) {
+      throw new Error(`cypress-network-idle: "${alias}" not found`)
+    }
+    const timeLimitMs = a2
+    return waitForIdle(counters, timeLimitMs)
   }
 
   const { method, pattern, timeLimitMs } = parseArgs(a1, a2, a3)
@@ -90,10 +98,11 @@ function waitForNetworkIdlePrepare({ method, pattern, alias } = {}) {
     throw new Error('cypress-network-idle: alias is required')
   }
 
-  const counters = (this[alias] = {
+  const counters = {
     callCount: 0,
     lastNetworkAt: null,
-  })
+  }
+  Cypress.env(`networkIdleCounters_${alias}`, counters)
 
   cy.intercept(method, pattern, (req) => {
     counters.callCount += 1

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,59 @@
 /// <reference types="cypress" />
 
-function waitForNetworkIdle(a1, a2, a3) {
+function waitForIdle(counters, timeLimitMs) {
+  counters.started = +new Date()
+  counters.finished
+  cy.log(`network idle for ${timeLimitMs} ms`)
+  cy.wrap('waiting...', { timeout: timeLimitMs * 3 })
+    .should(() => {
+      const t = counters.lastNetworkAt || counters.started
+      const elapsed = +new Date() - t
+      if (elapsed < timeLimitMs) {
+        // console.log('t =', t)
+        // console.log('elapsed', elapsed)
+        // console.log('timeLimitMs', timeLimitMs)
+        throw new Error('Network is busy')
+      }
+      counters.finished = +new Date()
+    })
+    .then(() => {
+      const waited = counters.finished - counters.started
+      cy.log(`finished after ${waited} ms`)
+      cy.wrap(
+        {
+          started: counters.started,
+          finished: counters.finished,
+          waited,
+          callCount: counters.callCount,
+        },
+        { log: false },
+      )
+    })
+}
+
+function waitForNetworkIdleImpl({ method, pattern, timeLimitMs }) {
+  const counters = {
+    callCount: 0,
+    lastNetworkAt: null,
+  }
+
+  // let callCount = 0
+  // let lastNetworkAt
+  cy.intercept(method, pattern, (req) => {
+    counters.callCount += 1
+    counters.lastNetworkAt = +new Date()
+    // console.log('out req at ', lastNetworkAt)
+    req.continue(() => {
+      // count the response timestamp
+      counters.lastNetworkAt = +new Date()
+      // console.log('response at', lastNetworkAt)
+    })
+  })
+
+  waitForIdle(counters, timeLimitMs)
+}
+
+function parseArgs(a1, a2, a3) {
   let method = 'GET'
   let pattern = '*'
   let timeLimitMs = 2000
@@ -20,39 +73,39 @@ function waitForNetworkIdle(a1, a2, a3) {
     throw new Error('Invalid arguments')
   }
 
-  let callCount = 0
-  let lastNetworkAt
+  return { method, pattern, timeLimitMs }
+}
+
+function waitForNetworkIdle(a1, a2, a3) {
+  if (typeof a1 === 'string' && a1.startsWith('@') && typeof a2 === 'number') {
+  }
+
+  const { method, pattern, timeLimitMs } = parseArgs(a1, a2, a3)
+
+  waitForNetworkIdleImpl({ method, pattern, timeLimitMs })
+}
+
+function waitForNetworkIdlePrepare({ method, pattern, alias } = {}) {
+  if (!alias) {
+    throw new Error('cypress-network-idle: alias is required')
+  }
+
+  const counters = (this[alias] = {
+    callCount: 0,
+    lastNetworkAt: null,
+  })
+
   cy.intercept(method, pattern, (req) => {
-    callCount += 1
-    lastNetworkAt = +new Date()
+    counters.callCount += 1
+    counters.lastNetworkAt = +new Date()
     // console.log('out req at ', lastNetworkAt)
     req.continue(() => {
       // count the response timestamp
-      lastNetworkAt = +new Date()
+      counters.lastNetworkAt = +new Date()
       // console.log('response at', lastNetworkAt)
     })
-  })
-
-  const started = +new Date()
-  let finished
-  cy.log(`network idle for ${timeLimitMs} ms`)
-  cy.wrap('waiting...', { timeout: timeLimitMs * 3 })
-    .should(() => {
-      const t = lastNetworkAt || started
-      const elapsed = +new Date() - t
-      if (elapsed < timeLimitMs) {
-        // console.log('t =', t)
-        // console.log('elapsed', elapsed)
-        // console.log('timeLimitMs', timeLimitMs)
-        throw new Error('Network is busy')
-      }
-      finished = +new Date()
-    })
-    .then(() => {
-      const waited = finished - started
-      cy.log(`finished after ${waited} ms`)
-      cy.wrap({ started, finished, waited, callCount }, { log: false })
-    })
+  }).as(alias)
 }
 
 Cypress.Commands.add('waitForNetworkIdle', waitForNetworkIdle)
+Cypress.Commands.add('waitForNetworkIdlePrepare', waitForNetworkIdlePrepare)


### PR DESCRIPTION
- closes #3 

```js
cy.waitForNetworkIdlePrepare({
  method: 'GET',
  pattern: '*',
  alias: 'calls',
})
cy.visit('/')
// now wait for the "@calls" to finish
cy.waitForNetworkIdle('@calls', 1000)
```