### PR TITLE
Feature: add optional timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+cypress/screenshots/
+cypress/videos/

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
   "supportFile": false,
   "pluginsFile": false,
-  "baseUrl": "http://localhost:60429"
+  "baseUrl": "http://localhost:3000"
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,5 @@
 {
   "supportFile": false,
   "pluginsFile": false,
-  "baseUrl": "http://localhost:3000"
+  "baseUrl": "http://localhost:60429"
 }

--- a/cypress/integration/delayed.js
+++ b/cypress/integration/delayed.js
@@ -17,3 +17,25 @@ it('uses the response timestamp', () => {
       expect(callCount, 'callCount').to.equal(1)
     })
 })
+
+it('fails when exceeding timeout', () => {
+  const message = 'Timed out retrying after 4000ms: Network is busy'
+  const failed = `Expected to fail with "${message}"`;
+  const passed = `${failed}, but it did not fail`;
+
+  cy.visit('/delayed')
+
+  cy.on('fail', (err) => {
+    if (err.message === passed) {
+      throw err
+    } else if (message) {
+      expect(err.message).to.include(message, failed)
+    }
+    return false
+  });
+
+  cy.waitForNetworkIdle('GET', '/user/delayed', 3000, { timeout: 4000 })
+  cy.then(() => {
+    throw new Error(passed)
+  });
+})

--- a/cypress/integration/delayed.js
+++ b/cypress/integration/delayed.js
@@ -20,8 +20,8 @@ it('uses the response timestamp', () => {
 
 it('fails when exceeding timeout', () => {
   const message = 'Timed out retrying after 4000ms: Network is busy'
-  const failed = `Expected to fail with "${message}"`;
-  const passed = `${failed}, but it did not fail`;
+  const failed = `Expected to fail with "${message}"`
+  const passed = `${failed}, but it did not fail`
 
   cy.visit('/delayed')
 
@@ -32,7 +32,7 @@ it('fails when exceeding timeout', () => {
       expect(err.message).to.include(message, failed)
     }
     return false
-  });
+  })
 
   cy.waitForNetworkIdle('GET', '/user/delayed', 3000, { timeout: 4000 })
   cy.then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 /// <reference types="cypress" />
 
-function waitForIdle(counters, timeLimitMs) {
+function waitForIdle(counters, timeLimitMs, timeout) {
   counters.started = +new Date()
   counters.finished = null
-
+  
   cy.log(`network idle for ${timeLimitMs} ms`)
-  cy.wrap('waiting...', { timeout: timeLimitMs * 3 })
+  cy.wrap('waiting...', { timeout })
     .should(() => {
       const t = counters.lastNetworkAt || counters.started
       const elapsed = +new Date() - t
@@ -32,7 +32,7 @@ function waitForIdle(counters, timeLimitMs) {
     })
 }
 
-function waitForNetworkIdleImpl({ method, pattern, timeLimitMs }) {
+function waitForNetworkIdleImpl({ method, pattern, timeLimitMs, timeout }) {
   const counters = {
     callCount: 0,
     lastNetworkAt: null,
@@ -52,47 +52,63 @@ function waitForNetworkIdleImpl({ method, pattern, timeLimitMs }) {
     })
   })
 
-  waitForIdle(counters, timeLimitMs)
+  waitForIdle(counters, timeLimitMs, timeout)
 }
 
-function parseArgs(a1, a2, a3) {
+function parseArgs(a1, a2, a3, a4) {
   let method = 'GET'
   let pattern = '*'
   let timeLimitMs = 2000
+  let timeout = Cypress.config('responseTimeout')
 
   if (typeof a1 === 'number') {
     timeLimitMs = a1
+    timeout = Math.max(timeout, timeLimitMs * 3)
+    if (typeof a2 === 'object' && a2.timeout) {
+      timeout = a2.timeout
+    }
   } else if (typeof a1 === 'string' && typeof a2 === 'number') {
     pattern = a1
     timeLimitMs = a2
+    timeout = Math.max(timeout, timeLimitMs * 3)
+    if (typeof a3 === 'object' && a3.timeout) {
+      timeout = a3.timeout
+    }
   } else if (typeof a1 === 'string' && typeof a2 === 'string') {
     method = a1
     pattern = a2
     if (typeof a3 === 'number') {
       timeLimitMs = a3
     }
+    timeout = Math.max(timeout, timeLimitMs * 3)
+    if (typeof a3 === 'object' && a3.timeout) {
+      timeout = a3.timeout
+    }
+    if (typeof a4 === 'object' && a4.timeout) {
+      timeout = a4.timeout
+    }
   } else {
     throw new Error('Invalid arguments')
   }
 
-  return { method, pattern, timeLimitMs }
+  return { method, pattern, timeLimitMs, timeout }
 }
 
-function waitForNetworkIdle(a1, a2, a3) {
-  if (typeof a1 === 'string' && a1.startsWith('@') && typeof a2 === 'number') {
-    const alias = a1.substr(1)
+function waitForNetworkIdle(...args) {
+  const { method, pattern, timeLimitMs, timeout } = parseArgs(...args)
+
+  if (typeof pattern === 'string' && pattern.startsWith('@')) {
+    const alias = pattern.substr(1)
 
     const counters = Cypress.env(`networkIdleCounters_${alias}`)
     if (!counters) {
       throw new Error(`cypress-network-idle: "${alias}" not found`)
     }
-    const timeLimitMs = a2
-    return waitForIdle(counters, timeLimitMs)
+
+    return waitForIdle(counters, timeLimitMs, timeout)
   }
 
-  const { method, pattern, timeLimitMs } = parseArgs(a1, a2, a3)
-
-  waitForNetworkIdleImpl({ method, pattern, timeLimitMs })
+  waitForNetworkIdleImpl({ method, pattern, timeLimitMs, timeout })
 }
 
 function waitForNetworkIdlePrepare({ method, pattern, alias } = {}) {


### PR DESCRIPTION
With this PR:

* The default timeout for the `waitForNetworkIdle` command is either `Cypress.config('responseTimeout')` or `timeLimitMs * 3` whichever is larger.
* The `waitForNetworkIdle` now accepts an options parameter with an optional `timeout` value.