### PR TITLE
adding interval, fixes after issue

### DIFF
--- a/cypress/integration/after.js
+++ b/cypress/integration/after.js
@@ -26,7 +26,7 @@ it('waits for the pending network call', () => {
     .then(({ waited, callCount }) => {
       // the page makes the Ajax call that resolves after 3 seconds
       // with 2 seconds of checking for network idle makes 5 seconds
-      expect(waited, 'waited ms').to.be.within(5000, 6000)
+      expect(waited, 'waited ms').to.be.within(5000, 6500)
       // the document and the Ajax
       expect(callCount, 'callCount').to.equal(2)
     })
@@ -40,5 +40,5 @@ it('waits for the pending network call', () => {
     .its('0.duration', { timeout: 0 })
     // because CI is slower than the local machine
     // we give it plenty of extra time in this assertion
-    .should('be.within', 3000, 3300)
+    .should('be.within', 3000, 3500)
 })

--- a/cypress/integration/delayed.js
+++ b/cypress/integration/delayed.js
@@ -13,7 +13,7 @@ it('uses the response timestamp', () => {
       // thus total resolve time should be:
       // 1000 + 1000 + 3000
       // but probably under 7 seconds
-      expect(waited, 'waited ms').to.be.within(5000, 7000)
+      expect(waited, 'waited ms').to.be.within(5000, 7200)
       expect(callCount, 'callCount').to.equal(1)
     })
 })
@@ -29,13 +29,13 @@ it('works with options object', () => {
       // thus total resolve time should be:
       // 1000 + 1000 + 3000
       // but probably under 7 seconds
-      expect(waited, 'waited ms').to.be.within(5000, 7000)
+      expect(waited, 'waited ms').to.be.within(5000, 7200)
       expect(callCount, 'callCount').to.equal(1)
     })
 })
 
 it('fails when exceeding timeout', () => {
-  const message = 'Timed out retrying after 4000ms: Network is busy'
+  const message = 'Network is busy'
   const failed = `Expected to fail with "${message}"`
   const passed = `${failed}, but it did not fail`
 


### PR DESCRIPTION
Adds an `interval` option with a default of 200 ms
Elapsed time is checked every `interval` ms
Doesn't throw any error until timeout is exceeded (fixed #31)