### PR TITLE
feat: add registerVisit function

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,21 @@ cy.waitForNetworkIdle(2000)
   .should('be.within', 2000, 3000)
 ```
 
+## Overwrite commands
+
+If you always want to want for network idle when calling `cy.visit` you can overwrite this command using the provided code in [src/register.js](./src/register.js) file
+
+```js
+// your spec
+const { registerVisit } = require('cypress-network-idle/src/register')
+registerVisit({ timeout: 1000 })
+
+it('waits for network idle', () => {
+  cy.visit('/')
+  // the network has been idle for 1 second
+})
+```
+
 ## Types
 
 This plugin includes the TypeScript types, import them from your JavaScript files using the reference types comment or via TS config.

--- a/cypress/integration/busy-page.js
+++ b/cypress/integration/busy-page.js
@@ -1,17 +1,8 @@
 /// <reference path="../../src/index.d.ts" />
 // @ts-check
 
-import '../..'
-
-Cypress.Commands.overwrite('visit', (visit, ...args) => {
-  cy.waitForNetworkIdlePrepare({
-    method: '*',
-    alias: 'visit',
-    pattern: '**',
-  })
-  visit(...args)
-  cy.waitForNetworkIdle('@visit', 1000)
-})
+const { registerVisit } = require('../../src/register')
+registerVisit({ timeout: 1000 })
 
 it('waits for the page to load its Ajax requests', () => {
   cy.intercept('GET', /\/after\/\d+$/).as('after')

--- a/src/register.js
+++ b/src/register.js
@@ -1,0 +1,26 @@
+/// <reference path="./index.d.ts" />
+
+require('./index')
+
+/**
+ * Overwrites the cy.visit command to wait for all network requests to finish.
+ * Options object can have "timeout" (ms) and "log" (boolean) properties.
+ * @example registerVisit({ timeout: 1000, log: false })
+ */
+function registerVisit(options = {}) {
+  const timeout = 'timeout' in options ? options.timeout : 1000
+  const log = 'log' in options ? options.log : true
+
+  Cypress.Commands.overwrite('visit', (visit, ...args) => {
+    cy.waitForNetworkIdlePrepare({
+      method: '*',
+      alias: 'visit',
+      pattern: '**',
+      log,
+    })
+    visit(...args)
+    cy.waitForNetworkIdle('@visit', timeout)
+  })
+}
+
+module.exports = { registerVisit }


### PR DESCRIPTION
```js
// your spec
const { registerVisit } = require('cypress-network-idle/src/register')
registerVisit({ timeout: 1000 })

it('waits for network idle', () => {
  cy.visit('/')
  // the network has been idle for 1 second
})