### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function waitForIdle(counters, timeLimitMs, timeout, interval) {
   if (log) {
     cy.log(`${logPrefix} for ${timeLimitMs} ms (timeout: ${timeout} ms)`)
   }
-  cy.wrap(`${logPrefix} waiting...`, { timeout, log }).should(check)
+  cy.wrap(`${logPrefix} waiting...`, { timeout, log }).then(check)
 
   function resetCounters() {
     counters.callCount = 0


### PR DESCRIPTION
A fix for error encountered due to changes in Cypress 12: Changing 'should' to 'then' fixed the issue

![cypress-network-idle-issue-1](https://user-images.githubusercontent.com/39652404/206390928-5336d61c-4a8a-4b72-a398-ba879d9b4551.PNG)
cy.should() failed because you invoked a command inside the callback. cy.should() retries the inner function, which would result in commands being added to the queue multiple times. Use cy.then() instead of cy.should(), or move any commands outside the callback function.

The command invoked was:

> cy.wait()

Because this error occurred during a before all hook we are skipping the remaining tests in the current suite: Users Grid node_modules/cypress-network-idle/src/index.js